### PR TITLE
Image selection crash catches

### DIFF
--- a/app/src/main/java/com/example/baard/CreateNewHabitEventFragment.java
+++ b/app/src/main/java/com/example/baard/CreateNewHabitEventFragment.java
@@ -17,6 +17,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.provider.MediaStore;
+import android.provider.OpenableColumns;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
@@ -340,16 +341,15 @@ public class CreateNewHabitEventFragment extends Fragment {
             Cursor cursor = getActivity().getContentResolver().query(
                     selectedImage, filePathColumn, null, null, null);
             cursor.moveToFirst();
-
             int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
             String filePath = cursor.getString(columnIndex);
             cursor.close();
             Bitmap myBitmap = BitmapFactory.decodeFile(filePath);
             if (filePath == null){
-                filePath = selectedImage.getPath();
+                // error, they probably didnt use Photos
+                Toast.makeText(getActivity(), "Please select an image with the Photos application.", Toast.LENGTH_LONG).show();
             }
             File file = new File(filePath);
-            double lengthOfFile = file.length();
             if (file.length() > 65536){
                 Toast.makeText(getActivity(), "Image is too large.", Toast.LENGTH_LONG).show();
                 return;

--- a/app/src/main/java/com/example/baard/CreateNewHabitEventFragment.java
+++ b/app/src/main/java/com/example/baard/CreateNewHabitEventFragment.java
@@ -309,7 +309,7 @@ public class CreateNewHabitEventFragment extends Fragment {
         getImage();
     }
 
-    public void getImage(){
+    private void getImage(){
         Intent getIntent = new Intent(Intent.ACTION_GET_CONTENT);
         getIntent.setType("image/*");
 
@@ -345,7 +345,11 @@ public class CreateNewHabitEventFragment extends Fragment {
             String filePath = cursor.getString(columnIndex);
             cursor.close();
             Bitmap myBitmap = BitmapFactory.decodeFile(filePath);
+            if (filePath == null){
+                filePath = selectedImage.getPath();
+            }
             File file = new File(filePath);
+            double lengthOfFile = file.length();
             if (file.length() > 65536){
                 Toast.makeText(getActivity(), "Image is too large.", Toast.LENGTH_LONG).show();
                 return;

--- a/app/src/main/java/com/example/baard/CreateNewHabitEventFragment.java
+++ b/app/src/main/java/com/example/baard/CreateNewHabitEventFragment.java
@@ -348,6 +348,7 @@ public class CreateNewHabitEventFragment extends Fragment {
             if (filePath == null){
                 // error, they probably didnt use Photos
                 Toast.makeText(getActivity(), "Please select an image with the Photos application.", Toast.LENGTH_LONG).show();
+                return;
             }
             File file = new File(filePath);
             if (file.length() > 65536){

--- a/app/src/main/java/com/example/baard/EditHabitEventActivity.java
+++ b/app/src/main/java/com/example/baard/EditHabitEventActivity.java
@@ -252,7 +252,14 @@ public class EditHabitEventActivity extends AppCompatActivity {
      * @param view supplied when button is pressed
      */
     public void onSelectImageButtonPress(View view){
-        checkReadPermission();
+        //TODO: TEST IF WE NEED THE CHECKREADPERMISSION FUNCTION
+        if (checkReadPermission() == -1){
+            return;
+        }
+        getImage();
+    }
+
+    private void getImage(){
         Intent getIntent = new Intent(Intent.ACTION_GET_CONTENT);
         getIntent.setType("image/*");
 

--- a/app/src/main/java/com/example/baard/EditHabitEventActivity.java
+++ b/app/src/main/java/com/example/baard/EditHabitEventActivity.java
@@ -309,6 +309,10 @@ public class EditHabitEventActivity extends AppCompatActivity {
             String filePath = cursor.getString(columnIndex);
             cursor.close();
             Bitmap myBitmap = BitmapFactory.decodeFile(filePath);
+            if (filePath == null){
+                // error, they probably didnt use Photos
+                Toast.makeText(this, "Please select an image with the Photos application.", Toast.LENGTH_LONG).show();
+            }
             File file = new File(filePath);
             if (file.length() > 65536){
                 Toast.makeText(this, "Image is too large.", Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/example/baard/EditHabitEventActivity.java
+++ b/app/src/main/java/com/example/baard/EditHabitEventActivity.java
@@ -312,6 +312,7 @@ public class EditHabitEventActivity extends AppCompatActivity {
             if (filePath == null){
                 // error, they probably didnt use Photos
                 Toast.makeText(this, "Please select an image with the Photos application.", Toast.LENGTH_LONG).show();
+                return;
             }
             File file = new File(filePath);
             if (file.length() > 65536){


### PR DESCRIPTION
Prevented crash when user selects image from an application that is not Photos. May have something to do with emulator storage, not sure. Decided not to pursue selecting images from any given application since this is not as high priority as friends social features.